### PR TITLE
Run tests in travis CI, in docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: required
+
+language: go
+
+services:
+  - docker
+
+env:
+  - DOCKER_COMPOSE_VERSION=1.22.0
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
+install:
+  - docker-compose build
+
+script:
+  - docker run modbridge:build go test -v ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Modbridge
 
+[![Build Status](https://travis-ci.com/mhemeryck/modbridge.svg?branch=master)](https://travis-ci.com/mhemeryck/modbridge)
+
 A tool for polling a modbus instance and pushing updates over MQTT.
 
 ## Quickstart


### PR DESCRIPTION
Run the local test suite against a CI.

There are plenty of ways of running the (small) test setup against
travis; most of them point to running the tests inside the travis
environment themselves and afterwards build and image to push through.

This is not really what I'd like, as this means you're not really
testing the same setup. Here, we can build the image in docker-compose
and afterwards take this image to run the tests in.