### PR TITLE
Adds subscribe to topic for all writable coils

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,16 +1,16 @@
 registers:
 coils:
 - address: 0
-  mode: "RW"
+  mode: "W"
   slug: "digital-output-1-1"
 - address: 1
-  mode: "RW"
+  mode: "W"
   slug: "digital-output-1-2"
 - address: 2
-  mode: "RW"
+  mode: "W"
   slug: "digital-output-1-3"
 - address: 3
-  mode: "RW"
+  mode: "W"
   slug: "digital-output-1-4"
 - address: 4
   mode: "RW"

--- a/configuration.go
+++ b/configuration.go
@@ -7,6 +7,7 @@ type ModbusMode string
 const (
 	Read      ModbusMode = "R"  // Read-only
 	ReadWrite            = "RW" // Both read and write allowed
+	Write                = "W"  // Write-only. Added for own purposes
 )
 
 // RegisterDataType indicates how to read the contents of the register


### PR DESCRIPTION
Closes #8 

Regular modbus coil mappings mention coils to be either read-only or
read-write. For our purposes here, a mode of "write-only" is added to
assure that we only use the coil for writing to from an incoming MQTT
event. Otherwise, the following would happen:
- MQTT event triggers coil update
- coil update; gets polled
- on poll, the coil pushes out another MQTT event, effectively undoing
the previous change (or even worse, leading to some infinite loop
behavior, depending on the topic and values used).

Put in infinite loop to keep connection open;
[SO](https://stackoverflow.com/questions/48872360/golang-mqtt-publish-and-subscribe)
has a solution based on an OS signal.