### PR TITLE
Bugfix polling coil groups of more than 8 coils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 - dep ensure -vendor-only
 
 script:
-- $GOPATH/bin/goveralls -service=travis-ci
+- $GOPATH/bin/goveralls -service=travis-ci -ignore=mocks/*.go
 
 after_success:
 - test -n "$TRAVIS_TAG" && docker login -u=mhemeryck -p="$DOCKER_PASSWORD"

--- a/coilgroup.go
+++ b/coilgroup.go
@@ -27,8 +27,8 @@ func (coilGroup *CoilGroup) Update() (err error) {
 		return
 	}
 	for k := range coilGroup.coils {
-		numberIndex := k / 16
-		bitOffset := uint16(k % 16)
+		numberIndex := k / 8
+		bitOffset := uint16(k % 8)
 		value := results[numberIndex] & (1 << bitOffset)
 		coilGroup.coils[k].Update(value != 0, coilGroup.MQTTClient)
 	}


### PR DESCRIPTION
Fixes #37 

When trying to do updates for coils in using the `CoilGroup.Update`, it
was assumed that the results from the modbus client were returned as an
array of `uint16`. However, they are in fact arrays of `byte`, so the
conversion scheme that was part of `CoilGroup.Update` was NOK and thus
was wrong in case of setups with more of 8 consecutive coils (including
my own).